### PR TITLE
v.0.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = assistant_bot
-version = 0.7.3
+version = 0.8.0
 
 [options]
 packages = find:


### PR DESCRIPTION
Added parameter of console:
  --output_console {1,2,3,4}
 Output console (1: TERMINAL, 2: TERMINAL_RICH, 3: TELEGRAM, 4: VIBER), default: 2